### PR TITLE
Fix warnings for Elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: elixir
 elixir: 
  - 1.2
+ - 1.3.4
+ - 1.4.0
 otp_release:
  - 18.0
+ - 19.0
 sudo: false

--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,11 @@ defmodule PipeHere.Mixfile do
     [app: :pipe_here,
      version: "1.0.0",
      elixir: "~> 1.2",
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/test/pipe_here_test.exs
+++ b/test/pipe_here_test.exs
@@ -5,6 +5,9 @@ defmodule PipeHereTest do
   import PipeHere.Assertions
   import PipeHere
 
+  # Silence "warning: unused import PipeHere"
+  pipe_here(nil)
+
   test "non-piped term expands to itself" do
     a = quote do
       a |> pipe_here


### PR DESCRIPTION
Thanks for pipe_here!

This PR fixes these warnings on Elixir 1.4:

```
# mix test
warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:8

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:9

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:12

Compiling 2 files (.ex)
Generated pipe_here app
warning: unused import PipeHere
  test/pipe_here_test.exs:6

...........

Finished in 0.04 seconds
11 tests, 0 failures

Randomized with seed 567707
```

and also updates `.travis.yml`.